### PR TITLE
Use a script with type=application/json instead of injecting js inline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 
 <!-- [![browser support][5]][6] -->
 
-Safely embed serialized javascript or JSON in a page as temporary global data.
-RegExp objects are properly serialized and HTML tags are sanitized.
+Safely embed serialized JSON in a page as temporary global data. HTML tags are sanitized.
 
 ## Example for the server
 
@@ -14,14 +13,14 @@ var JSONGlobals = require("safe-json-globals")
 
 function (req, res) {
     getUser(req, res, function (userRecord) {
-        var text = JSONGlobals({
+        var globalsMarkup = JSONGlobals({
           user: userRecord,
           potentialMaliciousContent: "</script><script>alert('hack')"
         })
 
         var html = "" // whatever html
 
-        html += "<script>" + text + "</script>"
+        html += globalsMarkup
 
         res.end(html)
     })

--- a/get.js
+++ b/get.js
@@ -1,8 +1,12 @@
-var window = require("global/window")
+var document = require("global/document")
 
 module.exports = getJSONGlobal
 
+var globals;
 function getJSONGlobal(key) {
-    var globals = window.__JSON_GLOBALS_ || {}
-    return globals[key]
+    if (!globals) {
+      var jsonGlobalsElement = document.getElementById('json-globals')
+      globals = JSON.parse(jsonGlobalsElement.textContent)
+    }
+    return globals[key];
 }

--- a/index.js
+++ b/index.js
@@ -9,15 +9,9 @@ function JSONGlobals(hash, value) {
         hash[key] = value
     }
 
-    var payload =
-        "if (!window.__JSON_GLOBALS_) {\n" +
-        "    window.__JSON_GLOBALS_ = {}\n" +
-        "}\n"
-
-    Object.keys(hash).forEach(function (key) {
-        payload += "window.__JSON_GLOBALS_[" + serializeJavascript(key) +
-            "] = " + serializeJavascript(hash[key]) + "\n"
-    })
+    var payload = '<script id="json-globals" type="application/json">';
+    payload += serializeJavascript(hash);
+    payload += '</script>';
 
     return payload
 }

--- a/test/index.js
+++ b/test/index.js
@@ -15,16 +15,10 @@ test("Can globalify stuff", function (assert) {
     })
 
     assert.equal(html,
-        "if (!window.__JSON_GLOBALS_) {\n" +
-        "    window.__JSON_GLOBALS_ = {}\n" +
-        "}\n" +
-
-        "window.__JSON_GLOBALS_[\"plain\"] = {\"name\":\"bob\"}\n" +
-        "window.__JSON_GLOBALS_[\"regex\"] = /foo/\n" +
-        "window.__JSON_GLOBALS_[\"malicious\"] = " +
-            "\"\\u003C\\u002Fscript\\u003E\"\n"
-    )
+      '<script id="json-globals" type="application/json">' +
+      '{"plain":{"name":"bob"},"regex":/foo/,"malicious":"\\u003C\\u002Fscript\\u003E"}' +
+      '</script>'
+    );
 
     assert.end()
 })
-


### PR DESCRIPTION
This solution removes the ability to serialize things such as regular expressions however it allows defining a csp that disallows inline scripts.
