### PR TITLE
remove globals and expose the get method for the browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,3 @@
+module.exports = {
+  get: require('./get.js');
+};

--- a/get.js
+++ b/get.js
@@ -1,5 +1,3 @@
-var document = require("global/document");
-
 module.exports = getJSONGlobal;
 
 var globals;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "keywords": [],
   "author": "Raynos <raynos2@gmail.com>",
   "repository": "git://github.com/lxe/safe-json-globals.git",
-  "main": "index",
+  "main": "index.js",
+  "browser": "browser.js",
   "homepage": "https://github.com/lxe/safe-json-globals",
   "contributors": [
     {
@@ -21,7 +22,6 @@
     "email": "lxe@lxe.co"
   },
   "dependencies": {
-    "global": "~4.3.0",
     "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This removes the `globals` library which dumps a bunch of shims for server-only DOM support. See https://github.com/sindresorhus/globals/issues/82
