### PR TITLE
[feature] add the ability to pass a custom parse function to deserial…

### DIFF
--- a/get.js
+++ b/get.js
@@ -3,10 +3,21 @@ var document = require("global/document");
 module.exports = getJSONGlobal;
 
 var globals;
-function getJSONGlobal(key) {
+
+/**
+ * @function getJSONGlobal
+ * @param {String} key key on globals to get
+ * @param {Object} [opts] options object
+ * @param {Function} [opts.parse = JSON.parse] parse function to run on the textContent, defaults to JSON.parse.
+ *                                             available since v2.1.0
+ */
+function getJSONGlobal(key, opts) {
+  opts = opts || {};
+  opts.parse = opts.parse || JSON.parse;
+
     if (!globals) {
       var jsonGlobalsElement = document.getElementById('json-globals');
-      globals = JSON.parse(jsonGlobalsElement.textContent);
+      globals = opts.parse(jsonGlobalsElement.textContent);
     }
     return globals[key];
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {
+    "proxyquire": "^1.8.0",
     "tape": "~4.4.0"
   },
   "licenses": [

--- a/test/index.js
+++ b/test/index.js
@@ -22,3 +22,5 @@ test("Can globalify stuff", function (assert) {
 
     assert.end()
 })
+
+require("./test-get");

--- a/test/test-get.js
+++ b/test/test-get.js
@@ -1,0 +1,42 @@
+var test = require("tape");
+
+// ensure we don't get any module from the cache, but to load it fresh every time
+var proxyquire = require('proxyquire').noPreserveCache();
+
+var TEXT_CONTENT = '{"foo": "bar"}';
+function requireGet() {
+  return proxyquire('../get', {
+    'global/document': {
+      getElementById: function getElementById(id) {
+        return {
+          textContent: TEXT_CONTENT
+        };
+      }
+    }
+  });
+}
+
+test("Default to using JSON.parse to deserialize global", function(assert) {
+  var get = requireGet();
+
+  assert.equal(get("foo"), "bar");
+
+  assert.end();
+});
+
+test("Use opts.parse to deserialize global if it is passed", function(assert) {
+  var get = requireGet();
+
+  assert.equal(
+    get("foo", {
+      parse: function parse(textContent) {
+        assert.equal(textContent, TEXT_CONTENT);
+        return { foo: "baz" };
+      }
+    }),
+
+    "baz"
+  );
+
+  assert.end();
+});


### PR DESCRIPTION
…ize globals

[`serialize-javascript`](https://www.npmjs.com/package/serialize-javascript) supports serializing a superset of `JSON` that can only be properly :100:% [desirialized
by using `eval`](https://github.com/yahoo/serialize-javascript/blob/2b1e4c78e3be3246390e2f723da70042cc4fcaf3/README.md#deserializing)

Here we add a second `opts` argument to `get` that allows you to specify a custom `parse` function, falling back to `JSON.parse` (thus being BC).

:white_check_mark: add unit test for `get` using [proxyquire](https://www.npmjs.com/package/proxyquire) for mocking dependencies

if landed semver would have you bump the package to `v2.1.0`