### PR TITLE
stringify fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function JSONGlobals(hash, value) {
     }
 
     var payload = '<script id="json-globals" type="application/json">';
-    payload += serializeJavascript(hash);
+    payload += JSON.stringify(hash);
     payload += '</script>';
 
     return payload


### PR DESCRIPTION
serialize-javascript and JSON.parse are incompatible. I replaced serialize-javascript with JSON.stringify which is just as safe, but only allows true JSON values.