### PR TITLE
Use eval to parse

### DIFF
--- a/get.js
+++ b/get.js
@@ -6,7 +6,8 @@ var globals;
 function getJSONGlobal(key) {
     if (!globals) {
       var jsonGlobalsElement = document.getElementById('json-globals');
-      globals = JSON.parse(jsonGlobalsElement.textContent);
+      globals = eval(
+        '(function() { return ' + jsonGlobalsElement.textContent + ';})();');
     }
     return globals[key];
 }


### PR DESCRIPTION
JSON.parse is incompatible with 'serialize-javascript'. If the payload has Date, Funciton, or Regex objects, JSON.parse will throw an error. serialize-javascript recommends to use `eval` to parse, which is what I've implemented here.

from [serialize-javascript README](https://github.com/yahoo/serialize-javascript):

----
## Deserializing

For some use cases you might also need to deserialize the string. This is explicitely not part of this module. However, you can easily write it yourself:

function deserialize(serializedJavascript){
  return eval('(' + serializedJavascript + ')');
}
Note: Don't forget the parentheses around the serialized javascript, as the opening bracket { will be considered to be the start of a body.

----

If we don't want to merge this fix, we should merge this one: https://github.com/lxe/safe-json-globals/pull/4