### PR TITLE
[refactor] "replace" serialize-javascript with JSON.stringify

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,11 @@ function JSONGlobals(hash, value) {
     }
 
     var payload = '<script id="json-globals" type="application/json">';
-    payload += serializeJavascript(hash);
+
+    // adding `isJSON` option makes it so that serializeJavascript behaves EXACTLY like `JSON.stringify` BUT sanitizes against XSS
+    // dates are serialized as strings, regex are empty objects, and functions are undefined
+    // @see https://github.com/yahoo/serialize-javascript/tree/2b1e4c78e3be3246390e2f723da70042cc4fcaf3#optionsisjson
+    payload += serializeJavascript(hash, {isJSON: true});
     payload += '</script>';
 
     return payload

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "serialize-javascript": "^1.1.2"
   },
   "devDependencies": {
+    "proxyquire": "^1.8.0",
     "tape": "~4.4.0"
   },
   "licenses": [

--- a/test/index.js
+++ b/test/index.js
@@ -11,14 +11,21 @@ test("Can globalify stuff", function (assert) {
     var html = JSONGlobals({
         plain: { name: "bob" },
         regex: /foo/,
-        malicious: '</script>'
+        malicious: '</script>',
+        date: new Date("2017-08-25T21:26:25.690Z"),
+        func: function foo() {
+            return 'bar';
+        }
     })
 
     assert.equal(html,
       '<script id="json-globals" type="application/json">' +
-      '{"plain":{"name":"bob"},"regex":/foo/,"malicious":"\\u003C\\u002Fscript\\u003E"}' +
+      '{"plain":{"name":"bob"},"regex":{},"malicious":"\\u003C\\u002Fscript\\u003E","date":"2017-08-25T21:26:25.690Z"}' +
       '</script>'
     );
 
     assert.end()
 })
+
+// run other tests
+require('./test-get')

--- a/test/test-get.js
+++ b/test/test-get.js
@@ -1,0 +1,21 @@
+var test = require("tape");
+
+// ensure we don't get any module from the cache, but to load it fresh every time
+var proxyquire = require("proxyquire").noPreserveCache();
+
+test("It should be able to get globals", function(assert) {
+  var get = proxyquire("../get", {
+    "global/document": {
+      getElementById: function getElementById(id) {
+        assert.equal(id, "json-globals", "it should call document.getElementById('json-globals')");
+        return {
+          textContent: '{"foo": "bar"}'
+        };
+      }
+    }
+  });
+
+  assert.equal(get("foo"), "bar");
+
+  assert.end();
+});


### PR DESCRIPTION
will require a major version bump after landing.

:art: We pass the [`isJSON` option](https://github.com/yahoo/serialize-javascript/tree/2b1e4c78e3be3246390e2f723da70042cc4fcaf3#optionsisjson) to `seralize-javascript`

adding `isJSON` option makes it so that serialize-javascript behaves **EXACTLY** like `JSON.stringify` **BUT** sanitizes against XSS
dates are serialized as strings, regex are empty objects, and functions are undefined (ie do not get stringified)

:white_check_mark: update existing unit test and add unit test for `get.js`

:memo: add code comments